### PR TITLE
Add CoreLocation import to iOS to squelch warnings & errors

### DIFF
--- a/src/ios/CDVBackgroundLocationServices.swift
+++ b/src/ios/CDVBackgroundLocationServices.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import CoreLocation
 
 let TAG = "[LocationServices]";
 let PLUGIN_VERSION = "1.0";


### PR DESCRIPTION
Add CoreLocation import to iOS to squelch warnings & errors around missing types.
