### PR TITLE
Unbind service when app activity is destroyed

### DIFF
--- a/src/android/BackgroundLocationServicesPlugin.java
+++ b/src/android/BackgroundLocationServicesPlugin.java
@@ -419,8 +419,9 @@ public class BackgroundLocationServicesPlugin extends CordovaPlugin {
     public void onDestroy() {
         Activity activity = this.cordova.getActivity();
 
-        if(isEnabled && stopOnTerminate.equalsIgnoreCase("true")) {
+        if(isEnabled) {
             activity.stopService(updateServiceIntent);
+            unbindServiceFromWebview(activity, updateServiceIntent);
         }
     }
 }


### PR DESCRIPTION
Unbind service when app activity is destroyed to prevent event handler leaking.
