### PR TITLE
Make startAggressiveTracking public

### DIFF
--- a/src/ios/CDVBackgroundLocationServices.swift
+++ b/src/ios/CDVBackgroundLocationServices.swift
@@ -156,7 +156,7 @@ var activityCommandDelegate:CDVCommandDelegate?;
         commandDelegate!.send(pluginResult, callbackId: command.callbackId);
     }
 
-    func startAggressiveTracking(command: CDVInvokedUrlCommand) {
+    func startAggressiveTracking(_ command: CDVInvokedUrlCommand) {
         log(message: "startAggressiveTracking");
         locationManager.startAggressiveTracking();
 


### PR DESCRIPTION
otherwise get an error message that it not a valid plugin method