### PR TITLE
Run iOS hook on platform_add

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -55,6 +55,7 @@
     <platform name="ios">
         <!-- required background modes:  App registers for location updates -->
         <hook type="after_plugin_install" src="hooks/add_swift_support.js"/>
+        <hook type="after_platform_add" src="hooks/add_swift_support.js"/>
         
         <config-file target="*-Info.plist" parent="NSLocationAlwaysUsageDescription">
             <string>${EXECUTABLE_NAME} Would Like to Use Your Current Location Even In Background.</string>


### PR DESCRIPTION
Hello,

If you add the iOS platform _after_ the plugin has been installed, the `after_plugin_install` hook is not run and Xcode complains of Swift version. This happens a lot in our workflow, in which platforms are removed and added for each full build.

Adding this hook solves the issue. It was tested with Cordova 6.5.